### PR TITLE
fix: incorrect determination of file type

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.5",
+  "version": "0.7.6",
   "npmClient": "pnpm",
   "packages": [
     ".",

--- a/liubai-backends/liubai-ffmpeg/package.json
+++ b/liubai-backends/liubai-ffmpeg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liubai-ffmpeg",
   "private": true,
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/liubai-backends/liubai-laf/package.json
+++ b/liubai-backends/liubai-laf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liubai-laf",
   "private": true,
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Liubai's backend for Laf",
   "main": "index.js",
   "scripts": {

--- a/liubai-docs/package.json
+++ b/liubai-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liubai-docs",
   "private": true,
-  "version": "0.7.5",
+  "version": "0.7.6",
   "type": "module",
   "description": "It's the docs center for Liubai",
   "author": {

--- a/liubai-frontends/liubai-web/package.json
+++ b/liubai-frontends/liubai-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liubai-web",
   "private": true,
-  "version": "0.7.5.4",
+  "version": "0.7.6",
   "description": "It's the frontend project for Liubai",
   "author": {
     "name": "yenche123",

--- a/liubai-frontends/liubai-web/package.json
+++ b/liubai-frontends/liubai-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liubai-web",
   "private": true,
-  "version": "0.7.5.1",
+  "version": "0.7.5.4",
   "description": "It's the frontend project for Liubai",
   "author": {
     "name": "yenche123",

--- a/liubai-frontends/liubai-web/package.json
+++ b/liubai-frontends/liubai-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liubai-web",
   "private": true,
-  "version": "0.7.5",
+  "version": "0.7.5.1",
   "description": "It's the frontend project for Liubai",
   "author": {
     "name": "yenche123",

--- a/liubai-frontends/liubai-web/src/components/editors/custom-editor/tools/useCeFile.ts
+++ b/liubai-frontends/liubai-web/src/components/editors/custom-editor/tools/useCeFile.ts
@@ -129,9 +129,12 @@ async function handleFiles(
   ceData: CeData,
   files: File[],
 ) {
+  const fileLength = files.length
   const imgFiles = liuUtil.getOnlyImageFiles(files)
+  const imgLength = imgFiles.length
   if(imgFiles.length > 0) {
     handleImages(ceData, imgFiles)
+    if(imgLength >= fileLength) return
   }
 
   const otherFiles = liuUtil.getNotImageFiles(files)

--- a/liubai-frontends/liubai-web/src/hooks/elements/useInputElement.ts
+++ b/liubai-frontends/liubai-web/src/hooks/elements/useInputElement.ts
@@ -88,8 +88,6 @@ async function tryToShowOpenFilePicker(
 
   try {
     handles = await window.showOpenFilePicker(options)
-    console.log("let me see handles: ")
-    console.log(handles)
   }
   catch(err) {
     console.warn("fail to call showOpenFilePicker")

--- a/liubai-frontends/liubai-web/src/hooks/elements/useInputElement.ts
+++ b/liubai-frontends/liubai-web/src/hooks/elements/useInputElement.ts
@@ -17,6 +17,10 @@ export function useInputElement() {
     const fsaAPI = liuApi.canIUse.fileSystemAccessAPI()
     if(fsaAPI) {
       const res = await tryToShowOpenFilePicker(opt)
+
+      console.warn("files from showOpenFilePicker: ")
+      console.log(res)
+
       return res
     }
     console.warn("Not supporting fileSystemAccessAPI")

--- a/liubai-frontends/liubai-web/src/utils/files/img-helper.ts
+++ b/liubai-frontends/liubai-web/src/utils/files/img-helper.ts
@@ -111,6 +111,7 @@ async function compress(files: File[]) {
 }
 
 function _toCompress(file: File) {
+  const fileSize = file.size
   const { width } = useWindowSize()
   let maxWidth = Math.floor(width.value * 2)
   if(maxWidth < 1280) maxWidth = 1280
@@ -122,7 +123,11 @@ function _toCompress(file: File) {
   else quality = 0.75
 
   const _excute = (a: CompressResolver) => {
-    const checkOrientation = file.size < CHECK_ORIENTATION_POINT
+    console.log("ready to compress, so see file size: ")
+    console.log(fileSize)
+    console.log(" ")
+
+    const checkOrientation = fileSize < CHECK_ORIENTATION_POINT
 
     const opt = {
       strict: true,

--- a/liubai-frontends/liubai-web/src/utils/liu-util/file-util.ts
+++ b/liubai-frontends/liubai-web/src/utils/liu-util/file-util.ts
@@ -1,8 +1,10 @@
 import type { LiuFileStore, LiuImageStore } from "~/types"
 import time from "../basic/time"
 import { getCharacteristic } from "../liu-api/characteristic"
+import valTool from "../basic/val-tool"
 
 const MIN_3 = 3 * time.MINUTE
+const IMG_SUFFIXES = ["png", "jpg", "jpeg", "gif", "webp"]
 
 // 获取允许的图片类型 由 , 拼接而成的字符串
 export function getAcceptImgTypesString() {
@@ -133,21 +135,46 @@ export function getArrayFromFileList(fileList: FileList): File[] {
   return arr
 }
 
-function isImageFile(file: File) {
-  const { type } = file
+interface IsImageRes {
+  result: boolean
+  newFile?: File
+}
 
-  console.log("type in isImageFile: ", type)
+
+function isImageFile(
+  file: File,
+): IsImageRes {
+  const { type, name, lastModified } = file
+
+  if(!type && name) {
+    const suffix = valTool.getSuffix(name)
+    if(!suffix) return { result: false }
+    const suffixMatched = IMG_SUFFIXES.includes(suffix)
+    if(!suffixMatched) return { result: false }
+    const newFile = new File([file], name, { 
+      type: `image/${suffix}`,
+      lastModified,
+    })
+
+    return { result: true, newFile }
+  }
 
   const arr = getAcceptImgTypesArray()
-  if(arr.includes(type)) return true
-  return type.startsWith("image/")
+  if(arr.includes(type)) return { result: true }
+  const prefixMatched = type.startsWith("image/")
+  if(!prefixMatched) return { result: false }
+  return { result: true }
 }
 
 export function getOnlyImageFiles(files: File[]): File[] {
   const imgFiles: File[] = []
   for(let i=0; i<files.length; i++) {
     const v = files[i]
-    if(isImageFile(v)) imgFiles.push(v)
+    const res1 = isImageFile(v)
+    if(!res1.result) continue
+    const { newFile } = res1
+    if(newFile) imgFiles.push(newFile)
+    else imgFiles.push(v)
   }
   return imgFiles
 }

--- a/liubai-frontends/liubai-web/src/utils/liu-util/file-util.ts
+++ b/liubai-frontends/liubai-web/src/utils/liu-util/file-util.ts
@@ -135,6 +135,9 @@ export function getArrayFromFileList(fileList: FileList): File[] {
 
 function isImageFile(file: File) {
   const { type } = file
+
+  console.log("type in isImageFile: ", type)
+
   const arr = getAcceptImgTypesArray()
   if(arr.includes(type)) return true
   return type.startsWith("image/")

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liubai",
   "private": true,
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Supercharge yourself!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#30 

It occurs from `showOpenFilePicker` and its handle.

When we used File System Access API on Android, the file object would be missing `type` property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - 将前端和后端包版本更新至 0.7.6。
- **Refactor**
  - 优化了文件上传及图像处理流程，确保在处理图像文件时逻辑更加健壮，提高了验证和压缩的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->