### PR TITLE
fix: for iQOO

### DIFF
--- a/liubai-docs/docs/.vitepress/config.mts
+++ b/liubai-docs/docs/.vitepress/config.mts
@@ -47,7 +47,7 @@ export default defineConfig({
               items: [
                 { text: "华为", link: "/guide/install/huawei" },
                 { text: "iPhone", link: "/guide/install/iphone" },
-                { text: "iQOO", link: "/guide/install/iqoo" },
+                { text: "iQOO", link: "/guide/install/iQOO" },
                 { text: "OPPO", link: "/guide/install/oppo" },
                 { text: "Realme", link: "/guide/install/realme" },
                 { text: "三星", link: "/guide/install/samsung" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - 更新了文档侧边栏中 iQOO 链接，修正了品牌名称的大小写不一致问题，确保展示符合正确的品牌规范。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->