### PR TITLE
feat: implement each_other_openid handling and update task card display

### DIFF
--- a/liubai-backends/liubai-laf/cloud-functions/common-types.ts
+++ b/liubai-backends/liubai-laf/cloud-functions/common-types.ts
@@ -4382,6 +4382,7 @@ export namespace PeopleTasksAPI {
     | "list-wx-tasks"
     | "update-task-title"
     | "update-task-note"
+    | "delete-wx-task"
 
   export interface Res_EnterWxChatTool {
     operateType: "enter-wx-chat-tool"

--- a/liubai-backends/liubai-laf/cloud-functions/common-types.ts
+++ b/liubai-backends/liubai-laf/cloud-functions/common-types.ts
@@ -4429,8 +4429,6 @@ export namespace PeopleTasksAPI {
     remindMe?: LiuRemindMe
     aiWorker?: LiuAi.AiWorker
 
-    // it only exists when chatInfo.open_single_roomid has been set
-    each_other_openid?: string
     note?: string
   }
 
@@ -4440,7 +4438,32 @@ export namespace PeopleTasksAPI {
     id: Sch_Id,
   })
 
-  export type WxTaskItem = Omit<Res_GetWxTask, "operateType">
+  export interface WxTaskItem {
+    infoType: "TASK" | "ACTIVITY"
+    id: string
+    activity_id?: string
+    desc: string
+    owner_openid: string
+    opengid?: string
+    open_single_roomid?: string
+    chat_type: WxMiniAPI.ChatType
+    assigneeList: AssigneeItem[]
+    participatorList?: ParticipatorItem[]
+    isMine?: boolean
+    insertedStamp: number
+    editedStamp?: number
+    endStamp?: number
+    closedStamp?: number
+
+    calendarStamp?: number
+    remindStamp?: number
+    whenStamp?: number
+    remindMe?: LiuRemindMe
+    aiWorker?: LiuAi.AiWorker
+    
+    each_other_openid?: string
+    note?: string
+  }
 
   export interface Res_ListWxTasks {
     operateType: "list-wx-tasks"

--- a/liubai-backends/liubai-laf/cloud-functions/common-types.ts
+++ b/liubai-backends/liubai-laf/cloud-functions/common-types.ts
@@ -4414,7 +4414,7 @@ export namespace PeopleTasksAPI {
     owner_openid: string
     opengid?: string
     open_single_roomid?: string
-    chat_type: number
+    chat_type: WxMiniAPI.ChatType
     assigneeList: AssigneeItem[]
     participatorList?: ParticipatorItem[]
     isMine?: boolean

--- a/liubai-backends/liubai-laf/cloud-functions/people-tasks.ts
+++ b/liubai-backends/liubai-laf/cloud-functions/people-tasks.ts
@@ -719,6 +719,20 @@ function packageWxTasks(
       note: v.note,
       each_other_openid: v.each_other_openid,
     }
+
+    // handle each_other_openid
+    if(v.open_single_roomid && v.assigneeList.length && !v.each_other_openid) {
+      const eachOther = v.assigneeList.find(v2 => {
+        if(v2.group_openid !== v.owner_openid) {
+          return true
+        }
+        return false
+      })
+      if(eachOther) {
+        obj.each_other_openid = eachOther.group_openid
+      }
+    }
+
     list.push(obj)
   }
   return list

--- a/liubai-backends/liubai-laf/cloud-functions/people-tasks.ts
+++ b/liubai-backends/liubai-laf/cloud-functions/people-tasks.ts
@@ -513,18 +513,7 @@ async function get_wx_task(
   }
 
   // 4. package data
-  const list4 = packageWxTasks([data2], userId)
-  const item4 = list4[0]
-  const data4: PeopleTasksAPI.Res_GetWxTask = {
-    operateType: "get-wx-task",
-    ...item4,
-  }
-
-  // 5. try to get each_other_openid
-  if(chatInfo?.open_single_roomid && !data4.each_other_openid) {
-    const each_other_openid = await getEachOtherOpenid(data4.assigneeList, chatInfo)
-    data4.each_other_openid = each_other_openid
-  }
+  const data4 = packageGetWxTask(data2, userId)
 
   return { code: "0000", data: data4 }
 }
@@ -685,6 +674,39 @@ async function checkTaskForSecurity(
   await wtCol.doc(id).update(w3)
 }
 
+
+function packageGetWxTask(
+  v: Table_WxTask,
+  myUserId: string,
+) {
+  const obj: PeopleTasksAPI.Res_GetWxTask = {
+    operateType: "get-wx-task",
+    id: v._id,
+    infoType: v.infoType ?? "TASK",
+    activity_id: v.activity_id,
+    desc: v.desc,
+    owner_openid: v.owner_openid,
+    opengid: v.opengid,
+    open_single_roomid: v.open_single_roomid,
+    chat_type: v.chat_type,
+    assigneeList: v.assigneeList,
+    participatorList: v.participatorList,
+    isMine: v.owner_userid === myUserId,
+    insertedStamp: v.insertedStamp,
+    editedStamp: v.editedStamp,
+    endStamp: v.endStamp,
+    closedStamp: v.closedStamp,
+
+    calendarStamp: v.calendarStamp,
+    remindStamp: v.remindStamp,
+    whenStamp: v.whenStamp,
+    remindMe: v.remindMe,
+    aiWorker: v.aiWorker,
+    
+    note: v.note,
+  }
+  return obj
+}
 
 
 function packageWxTasks(

--- a/liubai-backends/liubai-laf/cloud-functions/people-tasks.ts
+++ b/liubai-backends/liubai-laf/cloud-functions/people-tasks.ts
@@ -513,7 +513,7 @@ async function get_wx_task(
   }
 
   // 4. package data
-  const data4 = packageGetWxTask(data2, userId)
+  const data4 = packageResOfGetWxTask(data2, userId)
 
   return { code: "0000", data: data4 }
 }
@@ -675,7 +675,7 @@ async function checkTaskForSecurity(
 }
 
 
-function packageGetWxTask(
+function packageResOfGetWxTask(
   v: Table_WxTask,
   myUserId: string,
 ) {

--- a/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.ts
@@ -8,7 +8,7 @@ import { LiuUtil } from "~/utils/liu-util/index";
 import { LiuReq } from "~/requests/LiuReq";
 import APIs from "~/requests/APIs";
 import type { DeletedTaskEventDetail } from "./tools/types";
-import { turnTaskItemToResGetWxTask } from "./tools/useTaskCard";
+import { turnTaskCardToResGetWxTask } from "./tools/useTaskCard";
 
 Component({
 
@@ -36,7 +36,7 @@ Component({
       if(!obj?.id) return
       
       // 2. set tunnel
-      const obj2 = turnTaskItemToResGetWxTask(obj)
+      const obj2 = turnTaskCardToResGetWxTask(obj)
       LiuTunnel.setStuff("task-fr-list-to-detail", obj2)
 
       // 3. open chat tool

--- a/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.ts
@@ -2,13 +2,13 @@ import { sharedBehavior } from "~/behaviors/shared-behavior";
 import { i18nBehavior } from "~/behaviors/i18n-behavior"
 import { LiuApi } from "~/utils/LiuApi";
 import type { TaskItem } from "~/types/types-task";
-import type { PeopleTasksAPI } from "~/requests/req-types";
 import { LiuTunnel } from "~/utils/LiuTunnel";
 import type { WxMiniAPI } from "~/types/types-wx";
 import { LiuUtil } from "~/utils/liu-util/index";
 import { LiuReq } from "~/requests/LiuReq";
 import APIs from "~/requests/APIs";
 import type { DeletedTaskEventDetail } from "./tools/types";
+import { turnTaskItemToResGetWxTask } from "./tools/useTaskCard";
 
 Component({
 
@@ -36,10 +36,7 @@ Component({
       if(!obj) return
       
       // 2. set tunnel
-      const obj2: PeopleTasksAPI.Res_GetWxTask = {
-        operateType: "get-wx-task",
-        ...obj,
-      }
+      const obj2 = turnTaskItemToResGetWxTask(obj)
       LiuTunnel.setStuff("task-fr-list-to-detail", obj2)
 
       // 3. open chat tool

--- a/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.ts
@@ -1,7 +1,7 @@
 import { sharedBehavior } from "~/behaviors/shared-behavior";
 import { i18nBehavior } from "~/behaviors/i18n-behavior"
 import { LiuApi } from "~/utils/LiuApi";
-import type { TaskItem } from "~/types/types-task";
+import type { TaskCard } from "~/types/types-task";
 import { LiuTunnel } from "~/utils/LiuTunnel";
 import type { WxMiniAPI } from "~/types/types-wx";
 import { LiuUtil } from "~/utils/liu-util/index";
@@ -32,8 +32,8 @@ Component({
     onTapCard() {
       // 1. vibrate
       LiuApi.vibrateShort({ type: "light" })
-      const obj = this.data.task as TaskItem
-      if(!obj) return
+      const obj = this.data.task as TaskCard
+      if(!obj?.id) return
       
       // 2. set tunnel
       const obj2 = turnTaskItemToResGetWxTask(obj)
@@ -75,7 +75,7 @@ Component({
     },
 
     async toDelete() {
-      const task = this.data.task as TaskItem
+      const task = this.data.task as TaskCard
       if(!task) return
 
       const id = task.id

--- a/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.wxml
+++ b/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.wxml
@@ -22,9 +22,10 @@
     >
       <open-data-item type="userNickName" index="{{0}}" />
     </open-data-list>
-
     <text wx:else>{{t1.from_single_chat}}</text>
-    <text wx:if="{{task.eachOtherDone}}">{{t1.each_other_done}}</text>
+    <text wx:if="{{task.eachOtherDone}}" 
+      class="{{locale === 'en' ? 'tcf-left-margin' : ''}}"
+    >{{t1.each_other_done}}</text>
   </view>
 
 </view>

--- a/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.wxml
+++ b/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.wxml
@@ -16,8 +16,8 @@
   </view>
   <view wx:elif="{{task.open_single_roomid}}" class="task-card-footer">
 
-    <open-data-list wx:if="{{task.openidFromSingleChat}}"
-      members="{{[task.openidFromSingleChat]}}"
+    <open-data-list wx:if="{{task.otherOpenidForMe}}"
+      members="{{[task.otherOpenidForMe]}}"
       type="groupMembers"
     >
       <open-data-item type="userNickName" index="{{0}}" />

--- a/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.wxml
+++ b/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.wxml
@@ -16,13 +16,14 @@
   </view>
   <view wx:elif="{{task.open_single_roomid}}" class="task-card-footer">
 
-    <open-data-list wx:if="{{task.each_other_openid}}"
-      members="{{[task.each_other_openid]}}"
+    <open-data-list wx:if="{{task.openidFromSingleChat}}"
+      members="{{[task.openidFromSingleChat]}}"
       type="groupMembers"
     >
       <open-data-item type="userNickName" index="{{0}}" />
     </open-data-list>
     <text wx:else>{{t1.from_single_chat}}</text>
+    
     <text wx:if="{{task.eachOtherDone}}" 
       class="{{locale === 'en' ? 'tcf-left-margin' : ''}}"
     >{{t1.each_other_done}}</text>

--- a/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.wxss
+++ b/liubai-frontends/liubai-weixin/miniprogram/components/task-card/task-card.wxss
@@ -32,4 +32,9 @@
   font-size: var(--mini-font);
   color: var(--main-note);
   line-height: 1.45;
+  display: inline-flex;
+}
+
+.tcf-left-margin {
+  margin-left: 6px;
 }

--- a/liubai-frontends/liubai-weixin/miniprogram/components/task-card/tools/useTaskCard.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/components/task-card/tools/useTaskCard.ts
@@ -1,7 +1,7 @@
 import type { PeopleTasksAPI } from "~/requests/req-types";
 import type { TaskCard } from "~/types/types-task";
 
-export function turnTaskItemToResGetWxTask(
+export function turnTaskCardToResGetWxTask(
   obj: TaskCard,
 ) {
   const res: PeopleTasksAPI.Res_GetWxTask = {

--- a/liubai-frontends/liubai-weixin/miniprogram/components/task-card/tools/useTaskCard.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/components/task-card/tools/useTaskCard.ts
@@ -1,9 +1,8 @@
-import { PeopleTasksAPI } from "~/requests/req-types";
-import type { TaskItem } from "~/types/types-task";
-
+import type { PeopleTasksAPI } from "~/requests/req-types";
+import type { TaskCard } from "~/types/types-task";
 
 export function turnTaskItemToResGetWxTask(
-  obj: TaskItem,
+  obj: TaskCard,
 ) {
   const res: PeopleTasksAPI.Res_GetWxTask = {
     operateType: "get-wx-task",

--- a/liubai-frontends/liubai-weixin/miniprogram/components/task-card/tools/useTaskCard.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/components/task-card/tools/useTaskCard.ts
@@ -1,0 +1,35 @@
+import { PeopleTasksAPI } from "~/requests/req-types";
+import type { TaskItem } from "~/types/types-task";
+
+
+export function turnTaskItemToResGetWxTask(
+  obj: TaskItem,
+) {
+  const res: PeopleTasksAPI.Res_GetWxTask = {
+    operateType: "get-wx-task",
+    infoType: obj.infoType,
+    id: obj.id,
+    activity_id: obj.activity_id,
+    desc: obj.desc,
+    owner_openid: obj.owner_openid,
+    opengid: obj.opengid,
+    open_single_roomid: obj.open_single_roomid,
+    chat_type: obj.chat_type,
+    assigneeList: obj.assigneeList,
+    participatorList: obj.participatorList,
+    isMine: obj.isMine,
+    insertedStamp: obj.insertedStamp,
+    editedStamp: obj.editedStamp,
+    endStamp: obj.endStamp,
+    closedStamp: obj.closedStamp,
+
+    calendarStamp: obj.calendarStamp,
+    remindStamp: obj.remindStamp,
+    whenStamp: obj.whenStamp,
+    remindMe: obj.remindMe,
+    aiWorker: obj.aiWorker,
+    
+    note: obj.note,
+  }
+  return res
+}

--- a/liubai-frontends/liubai-weixin/miniprogram/locales/messages/en.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/locales/messages/en.ts
@@ -60,7 +60,7 @@ export default {
   "task-card": {
     "from_single_chat": "Single Chat",
     "all_done": "All Done",
-    "each_other_done": " | Each Other Done",
+    "each_other_done": "has done it",
     "done_1": "Done by ",
     "done_2": "",
   }

--- a/liubai-frontends/liubai-weixin/miniprogram/packageB/pages/task-detail/tools/types.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/packageB/pages/task-detail/tools/types.ts
@@ -26,7 +26,6 @@ export interface TaskDetail {
   remindStr?: string
   aiHelpStr?: string
   aiWorker?: LiuAi.AiWorker
-  each_other_openid?: string
   note?: string
 }
 

--- a/liubai-frontends/liubai-weixin/miniprogram/packageB/pages/task-detail/tools/useTaskDetail.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/packageB/pages/task-detail/tools/useTaskDetail.ts
@@ -95,7 +95,6 @@ export function showDetail(
     remindStr,
     aiHelpStr,
     aiWorker: data.aiWorker,
-    each_other_openid: data.each_other_openid,
     note: data.note,
   }
   return detail

--- a/liubai-frontends/liubai-weixin/miniprogram/packageB/requests/req-types.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/packageB/requests/req-types.ts
@@ -100,6 +100,11 @@ export namespace PeopleTasksAPI {
     group_openid: string
     doneStamp?: number
   }
+
+  export interface ParticipatorItem {
+    group_openid: string
+    engagedStamp?: number
+  }
   
   export interface Res_GetWxTask {
     operateType: "get-wx-task"
@@ -112,6 +117,7 @@ export namespace PeopleTasksAPI {
     open_single_roomid?: string
     chat_type: WxMiniAPI.ChatType
     assigneeList: AssigneeItem[]
+    participatorList?: ParticipatorItem[]
     isMine?: boolean
     insertedStamp: number
     editedStamp?: number
@@ -124,7 +130,6 @@ export namespace PeopleTasksAPI {
     remindMe?: LiuRemindMe
     aiWorker?: LiuAi.AiWorker
 
-    each_other_openid?: string
     note?: string
   }
 

--- a/liubai-frontends/liubai-weixin/miniprogram/pages/index/index.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/pages/index/index.ts
@@ -20,7 +20,7 @@ import {
   tryToOpenTaskDetail,
 } from "./tools/useIndexPage"
 import { pageBehavior } from "~/behaviors/page-behavior"
-import type { TaskItem } from "~/types/types-task"
+import type { TaskCard } from "~/types/types-task"
 import type { DeletedTaskEventDetail } from "~/components/task-card/tools/types"
 
 Component({
@@ -32,7 +32,7 @@ Component({
   data: {
     pageName: "index",
     canSearch: false,
-    myTasks: [] as TaskItem[],
+    myTasks: [] as TaskCard[],
     _key1: "",
     _key2: "",
     _taskId: "",

--- a/liubai-frontends/liubai-weixin/miniprogram/pages/index/tools/useIndexPage.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/pages/index/tools/useIndexPage.ts
@@ -1,7 +1,7 @@
 import APIs from "~/requests/APIs";
 import { LiuReq } from "~/requests/LiuReq";
 import type { PeopleTasksAPI } from "~/requests/req-types";
-import type { TaskItem } from "~/types/types-task";
+import type { TaskCard } from "~/types/types-task";
 import type { WxMiniAPI } from "~/types/types-wx";
 import { LiuApi } from "~/utils/LiuApi";
 import { LiuTunnel } from "~/utils/LiuTunnel";
@@ -104,12 +104,12 @@ export async function getMyTasks() {
 
 export async function getStoragedMyTasks() {
   const res = await LiuApi.getStorage({ key: "my-tasks" })
-  const data = res?.data as TaskItem[] | null
+  const data = res?.data as TaskCard[] | null
   if(!data) return
   return data
 }
 
-export async function setStoragedMyTasks(tasks: TaskItem[]) {
+export async function setStoragedMyTasks(tasks: TaskCard[]) {
   const res = await LiuApi.setStorage({ key: "my-tasks", data: tasks })
   return res
 }

--- a/liubai-frontends/liubai-weixin/miniprogram/requests/req-types.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/requests/req-types.ts
@@ -230,7 +230,10 @@ export namespace PeopleTasksAPI {
     remindMe?: LiuRemindMe
     aiWorker?: LiuAi.AiWorker
 
+    // 仅在单聊时，可能有值，其值表示除了 owner_openid 以外
+    // 的另一位 group_openid，而非相对于当前用户的另一位！
     each_other_openid?: string
+    
     note?: string
   }
 

--- a/liubai-frontends/liubai-weixin/miniprogram/requests/req-types.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/requests/req-types.ts
@@ -174,6 +174,11 @@ export namespace PeopleTasksAPI {
     group_openid: string
     doneStamp?: number
   }
+
+  export interface ParticipatorItem {
+    group_openid: string
+    engagedStamp?: number
+  }
   
   export interface Res_GetWxTask {
     operateType: "get-wx-task"
@@ -186,6 +191,33 @@ export namespace PeopleTasksAPI {
     open_single_roomid?: string
     chat_type: WxMiniAPI.ChatType
     assigneeList: AssigneeItem[]
+    participatorList?: ParticipatorItem[]
+    isMine?: boolean
+    insertedStamp: number
+    editedStamp?: number
+    endStamp?: number
+    closedStamp?: number
+
+    calendarStamp?: number
+    remindStamp?: number
+    whenStamp?: number
+    remindMe?: LiuRemindMe
+    aiWorker?: LiuAi.AiWorker
+    
+    note?: string
+  }
+
+  export interface WxTaskItem {
+    infoType: "TASK" | "ACTIVITY"
+    id: string
+    activity_id?: string
+    desc: string
+    owner_openid: string
+    opengid?: string
+    open_single_roomid?: string
+    chat_type: WxMiniAPI.ChatType
+    assigneeList: AssigneeItem[]
+    participatorList?: ParticipatorItem[]
     isMine?: boolean
     insertedStamp: number
     editedStamp?: number
@@ -201,8 +233,6 @@ export namespace PeopleTasksAPI {
     each_other_openid?: string
     note?: string
   }
-
-  export type WxTaskItem = Omit<Res_GetWxTask, "operateType">
 
   export interface Res_ListWxTasks {
     operateType: "list-wx-tasks"

--- a/liubai-frontends/liubai-weixin/miniprogram/types/types-task.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/types/types-task.ts
@@ -5,6 +5,7 @@ export interface TaskCard extends PeopleTasksAPI.WxTaskItem {
   doneCount?: number
   eachOtherDone?: boolean
 
-  // 在列表上，显示单聊里，除了我的另外一位的 group_openid
-  openidFromSingleChat?: string
+  // 在列表上，显示:
+  // 单聊里，相对于当前登录用户，另外一位的 group_openid
+  otherOpenidForMe?: string
 }

--- a/liubai-frontends/liubai-weixin/miniprogram/types/types-task.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/types/types-task.ts
@@ -1,8 +1,10 @@
 import type { PeopleTasksAPI } from "~/requests/req-types";
 
-export interface TaskItem extends PeopleTasksAPI.WxTaskItem {
+export interface TaskCard extends PeopleTasksAPI.WxTaskItem {
   allDone?: boolean
   doneCount?: number
   eachOtherDone?: boolean
-  openidFromSingleChat?: string  // 在列表上，显示来自哪个单聊的那个人的 group_openid
+
+  // 在列表上，显示单聊里，除了我的另外一位的 group_openid
+  openidFromSingleChat?: string
 }

--- a/liubai-frontends/liubai-weixin/miniprogram/types/types-task.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/types/types-task.ts
@@ -4,4 +4,5 @@ export interface TaskItem extends PeopleTasksAPI.WxTaskItem {
   allDone?: boolean
   doneCount?: number
   eachOtherDone?: boolean
+  openidFromSingleChat?: string  // 在列表上，显示来自哪个单聊的那个人的 group_openid
 }

--- a/liubai-frontends/liubai-weixin/miniprogram/utils/show/show-tasks.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/utils/show/show-tasks.ts
@@ -15,14 +15,14 @@ export function showTaskItems(
       eachOtherDone: undefined,
     }
 
-    // handle openidFromSingleChat
+    // handle otherOpenidForMe
     const isSingleChat = Boolean(task.open_single_roomid)
     if(isSingleChat) {
       if(task.isMine) {
-        obj.openidFromSingleChat = task.each_other_openid
+        obj.otherOpenidForMe = task.each_other_openid
       }
       else {
-        obj.openidFromSingleChat = task.owner_openid
+        obj.otherOpenidForMe = task.owner_openid
       }
     }
 

--- a/liubai-frontends/liubai-weixin/miniprogram/utils/show/show-tasks.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/utils/show/show-tasks.ts
@@ -1,14 +1,14 @@
 import type { PeopleTasksAPI } from "~/requests/req-types";
-import type { TaskItem } from "~/types/types-task";
+import type { TaskCard } from "~/types/types-task";
 
 export function showTaskItems(
   tasks: PeopleTasksAPI.WxTaskItem[],
 ) {
-  const list: TaskItem[] = []
+  const list: TaskCard[] = []
 
   for(let i=0; i<tasks.length; i++) {
     const task = tasks[i]
-    const obj: TaskItem = {
+    const obj: TaskCard = {
       ...task,
       allDone: undefined,
       doneCount: undefined,

--- a/liubai-frontends/liubai-weixin/miniprogram/utils/show/show-tasks.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/utils/show/show-tasks.ts
@@ -14,12 +14,23 @@ export function showTaskItems(
       doneCount: undefined,
       eachOtherDone: undefined,
     }
+
+    // handle openidFromSingleChat
+    const isSingleChat = Boolean(task.open_single_roomid)
+    if(isSingleChat) {
+      if(task.isMine) {
+        obj.openidFromSingleChat = task.each_other_openid
+      }
+      else {
+        obj.openidFromSingleChat = task.owner_openid
+      }
+    }
+
     if(task.infoType !== "TASK" || task.assigneeList.length < 1) {
       list.push(obj)
       continue
     }
 
-    const isSingleChat = Boolean(task.open_single_roomid)
     obj.allDone = true
     obj.doneCount = 0
     task.assigneeList.forEach(v => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 任务列表在存在单聊且未设置时会自动填充“对方会话ID”，列表与单条任务展示对齐，提升卡片与详情一致性。
- 样式
  - 调整任务卡片底部为 inline-flex 布局；新增左侧间距辅助类以优化英文场景标签间距。
- 文案
  - 英文文案更新为“has done it”，仅在“对方已完成”时展示；移除旧的备用显示路径。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->