### PR TITLE
Upgrade to v0.21.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.20.7",
+  "version": "0.21.0",
   "npmClient": "pnpm",
   "packages": [
     ".",

--- a/liubai-backends/liubai-ffmpeg/package.json
+++ b/liubai-backends/liubai-ffmpeg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liubai-ffmpeg",
   "private": true,
-  "version": "0.20.7",
+  "version": "0.21.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/liubai-backends/liubai-laf/package.json
+++ b/liubai-backends/liubai-laf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liubai-laf",
   "private": true,
-  "version": "0.20.7",
+  "version": "0.21.0",
   "description": "Liubai's backend for Laf",
   "main": "index.js",
   "scripts": {

--- a/liubai-docs/package.json
+++ b/liubai-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liubai-docs",
   "private": true,
-  "version": "0.20.7",
+  "version": "0.21.0",
   "type": "module",
   "description": "It's the docs center for Liubai",
   "author": {

--- a/liubai-frontends/liubai-vscode-extension/package.json
+++ b/liubai-frontends/liubai-vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "%package.displayName%",
   "description": "%package.description%",
   "publisher": "ptsd",
-  "version": "0.20.7",
+  "version": "0.21.0",
   "author": {
     "name": "yenche123",
     "email": "tsuiyenche@outlook.com",

--- a/liubai-frontends/liubai-web/package.json
+++ b/liubai-frontends/liubai-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liubai-web",
   "private": true,
-  "version": "0.20.7",
+  "version": "0.21.0",
   "description": "It's the frontend project for Liubai",
   "author": {
     "name": "yenche123",

--- a/liubai-frontends/liubai-weixin/miniprogram/packageB/pages/task-detail/tools/handleCalendar.ts
+++ b/liubai-frontends/liubai-weixin/miniprogram/packageB/pages/task-detail/tools/handleCalendar.ts
@@ -40,7 +40,7 @@ export function toAddCalendarEvent(
   }
 
   // 2. set timeout to prompt for system bug
-  const delay2 = 1250
+  const delay2 = 1750
   let timeout2: LiuTimeout = setTimeout(() => {
     timeout2 = undefined
     const isJustHidden = LiuTime.isWithinMillis(

--- a/liubai-frontends/liubai-weixin/package.json
+++ b/liubai-frontends/liubai-weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liubai-weixin",
-  "version": "0.20.7",
+  "version": "0.21.0",
   "description": "Liubai for Weixin",
   "scripts": {
     "pre-build": "tsx build/pre-build.ts"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liubai",
   "private": true,
-  "version": "0.20.7",
+  "version": "0.21.0",
   "description": "Supercharge yourself!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 微信小程序任务详情“添加到日历”流程：等待时长由1.25秒调整为1.75秒，相关提示出现时间相应延后。

- Chores
  - 全局版本号升级至0.21.0（根项目、文档、Web、VS Code 扩展、微信小程序、后端 ffmpeg 与 laf 等）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->