### PR TITLE
Simplify comment editor initialization to use commentId and ignore empty cache

### DIFF
--- a/liubai-frontends/liubai-web/src/components/custom-ui/comment-popup/comment-popup.vue
+++ b/liubai-frontends/liubai-web/src/components/custom-ui/comment-popup/comment-popup.vue
@@ -102,8 +102,6 @@ const onTapTopFooterBtn = () => {
         :focus-num="cpData.focusNum"
         :submit-num="cpData.submitNum"
         :show-submit-btn="!cpData.rightTopBtn"
-        :initial-content="cpData.operation === 'edit_comment' ? cpData.commentShow?.content : undefined"
-        :initial-files="cpData.operation === 'edit_comment' ? cpData.commentShow?.files : undefined"
         @finished="onFinished"
         @cansubmit="(newV) => cpData.canSubmit = newV"
       ></CommentEditor>

--- a/liubai-frontends/liubai-web/src/components/editors/comment-editor/comment-editor.vue
+++ b/liubai-frontends/liubai-web/src/components/editors/comment-editor/comment-editor.vue
@@ -11,8 +11,6 @@ import { useI18n } from 'vue-i18n';
 import { useCommentFile } from './tools/useCommentFile';
 import type { LocatedA } from "~/types/other/types-custom";
 import type { CeEmit } from "./tools/types"
-import type { TipTapJSONContent } from "~/types/types-editor"
-import type { LiuImageStore, LiuFileStore } from "~/types"
 
 const { t } = useI18n()
 
@@ -44,9 +42,6 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
-  initialContent: Object as PropType<TipTapJSONContent>,
-  initialImages: Array as PropType<LiuImageStore[]>,
-  initialFiles: Array as PropType<LiuFileStore[]>,
 })
 
 const emit = defineEmits<CeEmit>()

--- a/liubai-frontends/liubai-web/src/components/editors/comment-editor/tools/types.ts
+++ b/liubai-frontends/liubai-web/src/components/editors/comment-editor/tools/types.ts
@@ -4,7 +4,7 @@ import type {
   LiuImageStore,
 } from "~/types";
 import type { WorkspaceStore } from "~/hooks/stores/useWorkspaceStore";
-import type { TipTapEditor, TipTapJSONContent, EditorCoreContent } from "~/types/types-editor"
+import type { TipTapEditor, EditorCoreContent } from "~/types/types-editor"
 
 export interface CeReleasedData {
   text?: string
@@ -22,9 +22,6 @@ export interface CeProps {
   focusNum: number
   submitNum: number
   showSubmitBtn: boolean
-  initialContent?: TipTapJSONContent
-  initialImages?: LiuImageStore[]
-  initialFiles?: LiuFileStore[]
 }
 
 export interface CeEmit {

--- a/liubai-frontends/liubai-web/src/components/editors/comment-editor/tools/useCommentEditor.ts
+++ b/liubai-frontends/liubai-web/src/components/editors/comment-editor/tools/useCommentEditor.ts
@@ -213,13 +213,12 @@ async function initEditorContent(
   
   const atom = getStorageAtom(props)
   let res = commentCache.toGet(atom)
+  if(props.commentId && res && !hasStoredContent(res)) {
+    res = undefined
+  }
 
   if(!res) {
     if(props.commentId) {
-      if(props.initialContent || props.initialImages?.length || props.initialFiles?.length) {
-        setEditorContentFromProps(props, ctx, editor)
-        return
-      }
       initEditorContentFromDB(props, ctx, editor)
       return
     }
@@ -304,38 +303,11 @@ async function initEditorContentFromDB(
 }
 
 
-function setEditorContentFromProps(
-  props: CeProps,
-  ctx: CeCtx,
-  editor: TipTapEditor,
+function hasStoredContent(
+  atom: CommentStorageAtom,
 ) {
-  const { initialContent, initialImages, initialFiles } = props
-
-  // 由于是 "已发表后的编辑" 态，canSubmit 默认为 false
-  ctx.canSubmit = false
-  ctx.releasedData = {}
-
-  if(initialContent) {
-    const text = transferUtil.tiptapToText(initialContent.content ?? [])
-    editor.commands.setContent(initialContent)
-    ctx.editorContent = { text, json: initialContent }
-    ctx.isToolbarTranslateY = false
-    ctx.releasedData.text = text.trim()
-  }
-
-  if(initialImages?.length) {
-    ctx.images = valTool.copyObject(initialImages)
-    ctx.isToolbarTranslateY = false
-    ctx.releasedData.images = valTool.copyObject(initialImages)
-  }
-  if(initialFiles?.length) {
-    ctx.files = valTool.copyObject(initialFiles)
-    ctx.isToolbarTranslateY = false
-    ctx.releasedData.files = valTool.copyObject(initialFiles)
-  }
-
-  ctx.numWhenSet++
-  checkCanSubmit(props, ctx)
+  const text = atom.editorContent?.text?.trim()
+  return Boolean(text) || Boolean(atom.images?.length) || Boolean(atom.files?.length)
 }
 
 


### PR DESCRIPTION
### Motivation
- Make the comment editor responsibility centralized so the editor fetches its own published content when in edit mode using `commentId`, and avoid fragile behavior caused by passing external `initialContent`/`initialImages`/`initialFiles` that could be empty or stale.
- Prevent an empty cached storage atom from being used to populate the editor when editing an already-published comment, which caused the editor to show an empty state intermittently.

### Description
- Removed the `initialContent`, `initialImages`, and `initialFiles` props from the `CommentEditor` component and the `CeProps` type so parents no longer pass initial data into the editor (`liubai-frontends/liubai-web/src/components/custom-ui/comment-popup/comment-popup.vue` and `.../comment-editor/comment-editor.vue`).
- Simplified initialization logic in `initEditorContent` to ignore cached atoms that have no stored content when `props.commentId` is present, forcing a DB load via `initEditorContentFromDB` for edit mode (`liubai-frontends/liubai-web/src/components/editors/comment-editor/tools/useCommentEditor.ts`).
- Removed the `setEditorContentFromProps` flow and related imports/props cleanup, and kept a small helper `hasStoredContent` that checks `editorContent.text`, `images`, and `files` on a cached atom.
- Cleaned up related type imports and usages in `.../tools/types.ts` to reflect the removed props.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69815452f1688333a7d28b416dc66e73)